### PR TITLE
Added `type` slot for HSDSFile

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Description: This package provides functionality for reading data from HDF Scala
 	from within R.  The HSDSArray function bridges from HSDS to the user via the DelayedArray
 	interface.  Bioconductor manages an open HSDS instance graciously provided by John
 	Readey of the HDF Group.
-Version: 1.25.1
+Version: 1.25.2
 Authors@R: c(
  person("Samuela", "Pollack", role = c("aut"),email = "spollack@jimmy.harvard.edu"), 
  person("Shweta", "Gopaulakrishnan", role = c("aut"), email = "reshg@channing.harvard.edu"),

--- a/R/File.R
+++ b/R/File.R
@@ -7,7 +7,8 @@ deprecate_msg = paste0("This function is deprecated. The new interface to rhdf5c
 #' @slot domain the file's domain on the server; more or less, an alias for its 
 #' location in the external server file system
 #' @slot dsetdf a data.frame that caches often-used information about the file
-setClass("HSDSFile", representation(src="HSDSSource", domain="character", dsetdf="data.frame"))
+#' @slot type string representing type of the file: "domain" for file and "folder" for directory
+setClass("HSDSFile", representation(src="HSDSSource", domain="character", dsetdf="data.frame", type="character"))
 
 #' Construct an object of type HSDSFile
 #'
@@ -36,8 +37,16 @@ HSDSFile <- function(src, domain)  {
     warning("no such file")
     return(NULL)
   }
-  dsetdf <- findDatasets(src, domain)
-  obj <- new("HSDSFile", src=src, domain=domain, dsetdf=dsetdf)
+  type <- response$class
+  
+  if (type == "domain") {
+    dsetdf <- findDatasets(src, domain)  
+  } else {
+    dsetdf <- data.frame(paths=c(), uuids = c(), stringsAsFactors = FALSE)
+  }
+  
+  
+  obj <- new("HSDSFile", src=src, domain=domain, dsetdf=dsetdf, type=type)
 }
 
 .HSDSFile <- function(src, domain)  {  # after deprecation cycle this private function will be used
@@ -50,8 +59,15 @@ HSDSFile <- function(src, domain)  {
     warning("no such file")
     return(NULL)
   }
-  dsetdf <- findDatasets(src, domain)
-  obj <- new("HSDSFile", src=src, domain=domain, dsetdf=dsetdf)
+  type <- response$class
+  
+  if (type == "domain") {
+    dsetdf <- findDatasets(src, domain)  
+  } else {
+    dsetdf <- data.frame(paths=c(), uuids = c(), stringsAsFactors = FALSE)
+  }
+  
+  obj <- new("HSDSFile", src=src, domain=domain, dsetdf=dsetdf, type=type)
 }
 
 #' Search inner file hierarchy for datasets

--- a/tests/testthat/test.R
+++ b/tests/testthat/test.R
@@ -39,10 +39,21 @@ test_that("Files can be opened for reading", {
  if (check_hsds()) {
   src.hsds <- HSDSSource('https://hsdsdev.bioconductor.org')
   f1 <- HSDSFile(src.hsds, '/shared/bioconductor/tenx_full.h5')
+  expect_equal(f1@type, "domain")
   dsts <- listDatasets(f1)
   expect_true('/newassay001' %in% dsts)
   # catch exception: non-existent or empty file
   expect_error(HSDSFile(src.hsds, '/shared/bioconductor/tenx_nonex.h5'), "Not Found")
+  } else TRUE
+})
+
+test_that("HSDSFile can be a directory", {
+  if (check_hsds()) {
+    src.hsds <- HSDSSource('https://hsdsdev.bioconductor.org')
+    expect_no_warning(f1 <- HSDSFile(src.hsds, '/shared/bioconductor'))
+    expect_equal(f1@type, "folder")
+    subdomains <- listDomains(f1@src, f1@domain)
+    expect_true("/shared/bioconductor/tenx_full.h5" %in% subdomains)
   } else TRUE
 })
 


### PR DESCRIPTION
Hi Vincent,

This PR adds support for HSDSFile to represent a directory. It kind of worked before as well, but complained about "no datasets".

I'm not sure about your plans about `HSDSFile()` vs `.HSDSFile()`, so I modified both of them.